### PR TITLE
chore(.eslintrc.json): removed prop-types rule from eslintrc.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,7 +28,6 @@
 			}
 		],
     "react/function-component-definition": 0,
-    "react/prop-types": 0,
 		"react/react-in-jsx-scope": "off",
 		"prettier/prettier": [
 			"error",

--- a/src/components/Register/FormRedirection/FormRedirection.js
+++ b/src/components/Register/FormRedirection/FormRedirection.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 import './FormRedirection.scss'
 
@@ -10,5 +11,11 @@ const FormRedirection = ({ text, button, path }) => (
 		</Link>
 	</div>
 )
+
+FormRedirection.propTypes = {
+	text: PropTypes.string.isRequired,
+	button: PropTypes.string.isRequired,
+	path: PropTypes.string.isRequired,
+}
 
 export default FormRedirection

--- a/src/components/Register/FormTitle/FormTitle.js
+++ b/src/components/Register/FormTitle/FormTitle.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import './FormTitle.scss'
 
 const FormTitle = ({ greeting }) => (
@@ -6,5 +7,9 @@ const FormTitle = ({ greeting }) => (
 		<h1 className="form-title__greeting">{greeting}</h1>
 	</div>
 )
+
+FormTitle.propTypes = {
+	greeting: PropTypes.string.isRequired,
+}
 
 export default FormTitle

--- a/src/components/Register/Register.js
+++ b/src/components/Register/Register.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import './Register.scss'
 import FormTitle from './FormTitle/FormTitle'
 import RegistrationForm from './RegistrationForm/RegistrationForm'
@@ -15,5 +16,9 @@ const Register = ({ onRegister }) => (
 		/>
 	</section>
 )
+
+Register.propTypes = {
+	onRegister: PropTypes.func.isRequired,
+}
 
 export default Register

--- a/src/components/Register/RegistrationForm/RegistrationField/RegistrationField.js
+++ b/src/components/Register/RegistrationForm/RegistrationField/RegistrationField.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import './RegistrationField.scss'
 
 const RegistrationField = ({
@@ -31,5 +32,15 @@ const RegistrationField = ({
 		)}
 	</div>
 )
+
+RegistrationField.propTypes = {
+	label: PropTypes.string.isRequired,
+	name: PropTypes.string.isRequired,
+	placeholder: PropTypes.string.isRequired,
+	type: PropTypes.string.isRequired,
+	errors: PropTypes.objectOf(PropTypes.string).isRequired,
+	handleChange: PropTypes.func.isRequired,
+	values: PropTypes.objectOf(PropTypes.string).isRequired,
+}
 
 export default RegistrationField

--- a/src/components/Register/RegistrationForm/RegistrationForm.js
+++ b/src/components/Register/RegistrationForm/RegistrationForm.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import PropTypes from 'prop-types'
 import './RegistrationForm.scss'
 import RegistrationField from './RegistrationField/RegistrationField'
 import { NAME_REGEX, EMAIL_REGEX } from '../../../constants/regex'
@@ -159,6 +160,11 @@ const RegistrationForm = ({ button, onSubmit }) => {
 			</form>
 		</section>
 	)
+}
+
+RegistrationForm.propTypes = {
+	button: PropTypes.string.isRequired,
+	onSubmit: PropTypes.func.isRequired,
 }
 
 export default RegistrationForm


### PR DESCRIPTION
Убрала правило про PropTypes и дописала пропсы в компоненте Register (и всех его дочерних компонентах) 

Статья по использованию PropTypes
https://ru.react.js.org/docs/typechecking-with-proptypes.html